### PR TITLE
ci: fix to pass make check. Doc update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ Geographic visualisations for models' goodness of fit
 
 ## Purpose
 
-Geogof is a Python library for creating geographic visualizations to assess the goodness of fit between jydrologic models and observed data. The library stems from the observation that the author(s) had recurring needs for exploring model performance on maps (static or interactive) and kept repurposing or reinventing ad-hoc code for various projects. `geogof` will focus on visualisation, not data analysis or model calibration.
+`geogof` is a Python library for creating map-centric visualizations to assess the goodness of fit between hydrologic models and observed data. The library stems from the observation that the author(s) had recurring needs for exploring model performance on maps (static or interactive) and kept repurposing or reinventing ad-hoc code for various projects. `geogof` will deliberatrly focus on visualisation, **not** data analysis or model calibration.
 
 - **interactive dashboards**: ipyleaflet, perhaps folium.
 - **static maps**: matplotlib.
 
-A prior example, to give a visual of the intented use (from [monthly-lstm-runoff](https://csiro-hydroinformatics.github.io/monthly-lstm-runoff/)):
+A prior example, to give a visual idea of the intented use (from [monthly-lstm-runoff](https://csiro-hydroinformatics.github.io/monthly-lstm-runoff/)):
 
 <img src="https://csiro-hydroinformatics.github.io/monthly-lstm-runoff/img/model_benchmarking_dashboard_output.png" alt="interactive dashboard" width="700"/>
+
+This package is also the occasion to learn using [copier-uv](https://pawamoy.github.io/copier-uv/) for python packaging techniques and best practices.
 
 ## Installation
 
@@ -27,7 +29,7 @@ cd path/to/geogof
 uv pip install -e .
 ```
 
-or, in a requirement.txt file: 
+or, in a requirement.txt file:
 
 ```txt
 geogof @ git+https://github.com/csiro-hydroinformatics/geogof@main

--- a/src/geogof/__init__.py
+++ b/src/geogof/__init__.py
@@ -4,6 +4,6 @@ Geographic visualisations for models' goodness of fit
 """
 
 # from __future__ import annotations
-from . import points
+from geogof import points
 
 __all__: list[str] = ["points"]

--- a/src/geogof/points.py
+++ b/src/geogof/points.py
@@ -30,9 +30,9 @@ class PointData:
         lat_name: str = "lat",
         lon_name: str = "lon",
         obj_name: str = "obj",
-        lower_clip: float|None = None,
-        upper_clip: float|None = None,
-        fill_na_value: float=0,
+        lower_clip: float | None = None,
+        upper_clip: float | None = None,
+        fill_na_value: float = 0,
     ) -> None:
         """Initialize the class.
 


### PR DESCRIPTION
This change fixes the formatting to match `ruff` rules. A unit test still fails because of a dependency deprecation warning.  